### PR TITLE
Add drag camera panning

### DIFF
--- a/components/Camera.cs
+++ b/components/Camera.cs
@@ -23,6 +23,9 @@ public partial class Camera : Camera2D
     bool mouseWheelScrollingUp = false;
     bool mouseWheelScrollingDown = false;
 
+    bool isDragging = false;
+    Vector2 dragLastMousePos;
+
     // map boundaries
     float leftBound, rightBound, topBound, bottomBound;
 
@@ -72,6 +75,27 @@ public partial class Camera : Camera2D
             Position += new Vector2(0, velocity);
         }
 
+        // Mouse Drag Panning
+        if (Input.IsActionPressed("map_pan"))
+        {
+            Vector2 mousePos = GetViewport().GetMousePosition();
+            if (!isDragging)
+            {
+                isDragging = true;
+                dragLastMousePos = mousePos;
+            }
+            else
+            {
+                Vector2 deltaPos = mousePos - dragLastMousePos;
+                Position -= deltaPos * Zoom;
+                dragLastMousePos = mousePos;
+            }
+        }
+        else
+        {
+            isDragging = false;
+        }
+
         // Zoom Controls
         if (Input.IsActionPressed("map_kb_in") || mouseWheelScrollingUp)
         {
@@ -100,10 +124,11 @@ public partial class Camera : Camera2D
             mouseWheelScrollingDown = false;
         }
 
+        Position = new Vector2(
+            Mathf.Clamp(Position.X, leftBound, rightBound),
+            Mathf.Clamp(Position.Y, topBound, bottomBound)
+        );
 
         Zoom = new Vector2(Mathf.Clamp(Zoom.X, zoom_min, zoom_max), Mathf.Clamp(Zoom.Y, zoom_min, zoom_max));
     }
 }
-
-
-// TODO: Function to move the camera to a position

--- a/project.godot
+++ b/project.godot
@@ -67,6 +67,11 @@ map_mouse_in={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":4,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
+map_pan={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":3,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
 
 [rendering]
 


### PR DESCRIPTION
## Summary
- allow mouse drag to pan the camera
- clamp position after dragging
- add `map_pan` input action for middle mouse drag

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e43de85c833196d239b22a43ee63